### PR TITLE
Tweak IPFS gateways

### DIFF
--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -18,11 +18,7 @@ import {
   Metadata,
 } from './types';
 
-const IPFS_GATEWAYS = [
-  'https://cloudflare-ipfs.com',
-  'https://ipfs.io',
-  'https://w3s.link',
-];
+const IPFS_GATEWAYS = ['https://ipfs.io', 'https://cloudflare-ipfs.com'];
 
 /**
  * Given a URI that may be ipfs, ipns, http, https, ar, or data protocol, return the fetch-able http(s) URLs for the same content

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -18,7 +18,7 @@ import {
   Metadata,
 } from './types';
 
-const IPFS_GATEWAYS = ['https://ipfs.io', 'https://cloudflare-ipfs.com'];
+const IPFS_GATEWAYS = ['https://cloudflare-ipfs.com', 'https://ipfs.io'];
 
 /**
  * Given a URI that may be ipfs, ipns, http, https, ar, or data protocol, return the fetch-able http(s) URLs for the same content

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -19,7 +19,7 @@ import {
 } from './types';
 
 const IPFS_GATEWAYS = [
-  'https://gateway.ipfs.io',
+  'https://dweb.link',
   'https://cloudflare-ipfs.com',
   'https://ipfs.io',
 ];

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -18,7 +18,11 @@ import {
   Metadata,
 } from './types';
 
-const IPFS_GATEWAYS = ['https://cloudflare-ipfs.com', 'https://ipfs.io'];
+const IPFS_GATEWAYS = [
+  'https://gateway.ipfs.io',
+  'https://cloudflare-ipfs.com',
+  'https://ipfs.io',
+];
 
 /**
  * Given a URI that may be ipfs, ipns, http, https, ar, or data protocol, return the fetch-able http(s) URLs for the same content

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -19,7 +19,7 @@ import {
 } from './types';
 
 const IPFS_GATEWAYS = [
-  'https://dweb.link',
+  'https://character-sheets.infura-ipfs.io',
   'https://cloudflare-ipfs.com',
   'https://ipfs.io',
 ];


### PR DESCRIPTION
- Remove `https://w3s.link` since it doesn't work, and make `https://ipfs.io` the primary