### PR TITLE
Handle IPFS images better

### DIFF
--- a/hooks/useUploadFile.ts
+++ b/hooks/useUploadFile.ts
@@ -33,7 +33,7 @@ export const useUploadFile = ({
     try {
       setIsUploading(true);
       const formData = new FormData();
-      formData.set(file.name, file);
+      formData.set(fileName, file);
 
       const response = await fetch(`/api/uploadFile?name=${fileName}`, {
         method: 'POST',

--- a/pages/api/uploadTraits.ts
+++ b/pages/api/uploadTraits.ts
@@ -159,7 +159,7 @@ export default async function uploadTraits(
 
     const fileContents = await imageComposite
       .quality(85)
-      .resize(700, 925)
+      .resize(700, Jimp.AUTO)
       .getBufferAsync(Jimp.MIME_JPEG);
 
     const file = new File([fileContents], 'characterAvater.jpg');

--- a/pages/api/uploadTraits.ts
+++ b/pages/api/uploadTraits.ts
@@ -157,9 +157,12 @@ export default async function uploadTraits(
       return acc.composite(image, 0, 0);
     });
 
-    const fileContents = await imageComposite.getBufferAsync(Jimp.MIME_PNG);
+    const fileContents = await imageComposite
+      .quality(85)
+      .resize(700, 925)
+      .getBufferAsync(Jimp.MIME_JPEG);
 
-    const file = new File([fileContents], 'characterAvater.png');
+    const file = new File([fileContents], 'characterAvater.jpg');
 
     const attributes = getAttributesFromTraitsObject(traits);
     const cid = await uploadToWeb3Storage(file);

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -6,6 +6,7 @@ import {
   ItemInfoFragment,
   ItemRequirementInfoFragment,
 } from '@/graphql/autogen/types';
+import { ENVIRONMENT } from '@/utils/constants';
 
 import {
   Character,
@@ -18,11 +19,11 @@ import {
   Metadata,
 } from './types';
 
-const IPFS_GATEWAYS = [
-  'https://character-sheets.infura-ipfs.io',
-  'https://cloudflare-ipfs.com',
-  'https://ipfs.io',
-];
+const IPFS_GATEWAYS = ['https://cloudflare-ipfs.com', 'https://ipfs.io'];
+
+if (ENVIRONMENT === 'main') {
+  IPFS_GATEWAYS.unshift('https://character-sheets.infura-ipfs.io');
+}
 
 /**
  * Given a URI that may be ipfs, ipns, http, https, ar, or data protocol, return the fetch-able http(s) URLs for the same content


### PR DESCRIPTION
- Doesn't close but is associated #96 
- Closes #121 
- Ensures that all image uploads are less than 200 KB
- Separately, a script was run to compress all existing images