### PR TITLE
Skip Jimp for SVG uploads

### DIFF
--- a/components/Modals/EquipItemModal.tsx
+++ b/components/Modals/EquipItemModal.tsx
@@ -10,7 +10,7 @@ import {
   Text,
   VStack,
 } from '@chakra-ui/react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { parseAbi } from 'viem';
 import { Address, usePublicClient, useWalletClient } from 'wagmi';
 
@@ -40,8 +40,9 @@ export const EquipItemModal: React.FC = () => {
   const [txFailed, setTxFailed] = useState<boolean>(false);
   const [isSyncing, setIsSyncing] = useState<boolean>(false);
   const [isSynced, setIsSynced] = useState<boolean>(false);
+  const [isEquipped, setIsEquipped] = useState<boolean>(false);
 
-  const isEquipped = useMemo(() => {
+  const onSetIsEquipped = useCallback(() => {
     if (!selectedItem || !character) {
       return false;
     }
@@ -51,6 +52,11 @@ export const EquipItemModal: React.FC = () => {
       undefined
     );
   }, [character, selectedItem]);
+
+  useEffect(() => {
+    if (!!txHash) return;
+    setIsEquipped(onSetIsEquipped());
+  }, [onSetIsEquipped, txHash]);
 
   const resetData = useCallback(() => {
     setTxHash(null);
@@ -63,7 +69,7 @@ export const EquipItemModal: React.FC = () => {
     if (!equipItemModal?.isOpen) {
       resetData();
     }
-  }, [resetData, equipItemModal?.isOpen]);
+  }, [equipItemModal?.isOpen, resetData]);
 
   const onEquipItem = useCallback(
     async (e: React.FormEvent<HTMLDivElement>) => {

--- a/pages/api/uploadFile.ts
+++ b/pages/api/uploadFile.ts
@@ -1,4 +1,5 @@
 import formidable from 'formidable';
+import fs from 'fs';
 import Jimp from 'jimp';
 import type { NextApiRequest, NextApiResponse, PageConfig } from 'next';
 
@@ -28,6 +29,15 @@ export default async function uploadFile(
   const fileName = req.query.name as string;
   const form = formidable({});
 
+  let isSvg = false;
+  form.on('file', (_, file) => {
+    const mimeType = file.mimetype;
+
+    if (mimeType === 'image/svg+xml') {
+      isSvg = true;
+    }
+  });
+
   try {
     const [, files] = await form.parse(req);
     const formFile = files[fileName] as [FormFile] | undefined;
@@ -36,10 +46,16 @@ export default async function uploadFile(
       return res.status(400).json({ error: 'No file provided' });
     }
 
-    const image = await Jimp.read(formFile[0]._writeStream.path);
-    const fileContents = await image
-      .resize(700, Jimp.AUTO)
-      .getBufferAsync(Jimp.MIME_PNG);
+    let fileContents: Buffer;
+
+    if (isSvg) {
+      fileContents = fs.readFileSync(formFile[0]._writeStream.path);
+    } else {
+      const image = await Jimp.read(formFile[0]._writeStream.path);
+      fileContents = await image
+        .resize(700, Jimp.AUTO)
+        .getBufferAsync(Jimp.MIME_PNG);
+    }
 
     const cid = await uploadToPinata(fileContents, `${fileName}.png`);
     if (!cid) {


### PR DESCRIPTION
- Jimp does not allow SVG reading
    - Since SVGs are tiny, we don't really need to compress them with Jimp anyway
- This PR also fixes equip/unequip text issue in the `EquipItemModal`