### PR TITLE
Fix uploadTraits layer resize issue

### DIFF
--- a/pages/api/uploadTraits.ts
+++ b/pages/api/uploadTraits.ts
@@ -36,7 +36,7 @@ export default async function uploadTraits(
       traitsArray.map(async trait => {
         const url = getImageUrl(trait);
         const image = await Jimp.read(url);
-        return image;
+        return image.resize(700, Jimp.AUTO);
       }),
     );
 
@@ -46,7 +46,6 @@ export default async function uploadTraits(
 
     const fileContents = await imageComposite
       .quality(85)
-      .resize(700, Jimp.AUTO)
       .getBufferAsync(Jimp.MIME_JPEG);
 
     const attributes = getAttributesFromTraitsObject(traitsObject);


### PR DESCRIPTION
### Issue
- Resize was occurring only at the end with the composite image
- If the item layer was a different size than the character layers, things wouldn't match up

### Solution
- Resize every layer before it gets added to the composite